### PR TITLE
Run images as non-root user.

### DIFF
--- a/java11_linux.Dockerfile
+++ b/java11_linux.Dockerfile
@@ -1,5 +1,9 @@
 FROM eclipse-temurin:11
 
+# Add a new user "nonRoot" with user id 1234
+# This user will be used by bitbucket-pipelines.yml files.
+RUN useradd -u 1234 nonRoot
+
 # We need Tesseract 4.1.x
 RUN apt-get update \
   && apt-get install software-properties-common -y \

--- a/java17_linux.Dockerfile
+++ b/java17_linux.Dockerfile
@@ -1,5 +1,9 @@
 FROM eclipse-temurin:17
 
+# Add a new user "nonRoot" with user id 1234
+# This user will be used by bitbucket-pipelines.yml files.
+RUN useradd -u 1234 nonRoot
+
 # We need Tesseract 4.1.x
 RUN apt-get update \
   && apt-get install software-properties-common -y \


### PR DESCRIPTION
The root user previously used (as default) meant certain tests failed in Bitbucket Pipelines. We cannot specify a read-only user that overrides the image default, so the image itself must specify a non-root user. See Bitbucket support ticket BBS-182793.