### PR TITLE
Run images as non-root user.

### DIFF
--- a/java11_linux.Dockerfile
+++ b/java11_linux.Dockerfile
@@ -1,9 +1,5 @@
 FROM eclipse-temurin:11
 
-# Add a new user "nonRoot" with user id 1234
-# This user will be used by bitbucket-pipelines.yml files.
-RUN useradd -u 1234 nonRoot
-
 # We need Tesseract 4.1.x
 RUN apt-get update \
   && apt-get install software-properties-common -y \
@@ -12,3 +8,12 @@ RUN apt-get update \
   && apt-get install tesseract-ocr git -y \
   && rm -rf /var/lib/apt/lists/*
 ENV GRADLE_OPTS=-Dkotlin.compiler.execution.strategy="in-process"
+
+# Add a new user group "nonRoot".
+# Add a new user "nonRoot" with user id 1234 to this group.
+# This user will be used by bitbucket-pipelines.yml files.
+RUN groupadd --gid 1234 newgroup
+RUN useradd -g newgroup --uid 1234 nonRootUser
+
+USER nonRootUser
+RUN whoami

--- a/java17_linux.Dockerfile
+++ b/java17_linux.Dockerfile
@@ -1,9 +1,5 @@
 FROM eclipse-temurin:17
 
-# Add a new user "nonRoot" with user id 1234
-# This user will be used by bitbucket-pipelines.yml files.
-RUN useradd -u 1234 nonRoot
-
 # We need Tesseract 4.1.x
 RUN apt-get update \
   && apt-get install software-properties-common -y \
@@ -12,3 +8,12 @@ RUN apt-get update \
   && apt-get install tesseract-ocr git -y \
   && rm -rf /var/lib/apt/lists/*
 ENV GRADLE_OPTS=-Dkotlin.compiler.execution.strategy="in-process"
+
+# Add a new user group "nonRoot".
+# Add a new user "nonRoot" with user id 1234 to this group.
+# This user will be used by bitbucket-pipelines.yml files.
+RUN groupadd --gid 1234 newgroup
+RUN useradd -g newgroup --uid 1234 nonRootUser
+
+USER nonRootUser
+RUN whoami


### PR DESCRIPTION
The root user previously used (as default) meant certain tests failed in Bitbucket Pipelines. We cannot specify a read-only user that overrides the image default, so the image itself must specify a non-root user. See Bitbucket support ticket BBS-182793.