### PR TITLE
Update docker image to use a new base image

### DIFF
--- a/java11_linux.Dockerfile
+++ b/java11_linux.Dockerfile
@@ -1,4 +1,7 @@
-FROM eclipse-temurin:11
+# Pinned to the final focal-based Adoptium JDK 11 build.
+# Focal is required because the alex-p Tesseract PPA does not publish for jammy or
+# newer Ubuntu codenames.
+FROM eclipse-temurin:11.0.27_6-jdk-focal
 
 # We need Tesseract 4.1.x
 RUN apt-get update \

--- a/java17_linux.Dockerfile
+++ b/java17_linux.Dockerfile
@@ -1,4 +1,7 @@
-FROM eclipse-temurin:17
+# Pinned to the final focal-based Adoptium JDK 17 build.
+# Focal is required because the alex-p Tesseract PPA does not publish for jammy or
+# newer Ubuntu codenames.
+FROM eclipse-temurin:17.0.15_6-jdk-focal
 
 # We need Tesseract 4.1.x
 RUN apt-get update \


### PR DESCRIPTION
The TLS cert on packages.smartcrypt.com was recently updated. The new cert was signed with a Sectigo root certificate that was not included in the previous image's trust store, due to it not having been built in 4 years.

The Eclipse-temurin:17 tag now resolves to Ubuntu noble (Adoptium switched in July 2024), and the alex-p/tesseract-ocr PPA we use for Tesseract 4.1.3 has no jammy or noble release. Jammy ships with tesseract 4.1.1, but this is a slight downgrade from 4.1.3. I don't know enough about how we use tesseract to know if the version difference will matter, but I didn't want to risk it. Noble's main archive ships 5.3.4 (a major version bump that would break our 4.1.x-specific behavior).

Pinning to a focal-based Adoptium tag (17.0.15_6-jdk-focal) keeps the original PPA install path working and preserves Tesseract 4.1.3 exactly, while still picking up a newer JDK patch that includes the Sectigo R46 root cert needed for TLS to packages.smartcrypt.com.

It should be noted that focal is EOL as of last year, so we need a future decision to either 1.) build Tesseract 4.1.3 ourselves as part of the image, accept a slightly older tesseract version (4.1.1), deprecate this image, or find another solution.